### PR TITLE
add randomized sort support to full-text recipe

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,7 +26,7 @@ dependencies = [
   "pydantic >= 2.12.5",
   
   # MediaCloud integration
-  "mediacloud >= 5.0.0",
+  "mediacloud >= 5.1.0",
   "mediacloud-metadata",
   "mc-providers @ git+https://github.com/mediacloud/mc-providers@v4.4.latest",
   "wayback-news-search >= 1.2.0",

--- a/sous_chef/flows/full_text_download_flow.py
+++ b/sous_chef/flows/full_text_download_flow.py
@@ -5,6 +5,9 @@ This flow queries MediaCloud for articles, extracts the full text along with
 basic metadata, and exports it as a CSV file to Backblaze B2.
 """
 import pandas as pd
+import logging
+from pydantic import BaseModel, Field
+
 from ..flow import register_flow, BaseFlowOutput
 from ..runtime import mark_step
 from ..params.mediacloud_query import MediacloudQuery
@@ -21,18 +24,23 @@ from ..tasks.email_tasks import send_run_summary_email
 from ..utils import create_url_safe_slug, get_logger
 
 
-class FullTextDownloadParams(
-    MediacloudQuery,
-    CsvExportParams,
-    EmailRecipientParam,
-    WebhookCallbackParam,
-):
+class FullTextDownloadParams(MediacloudQuery, CsvExportParams, EmailRecipientParam, WebhookCallbackParam):
     """Parameters for the full-text download flow."""
+    max_articles: int = Field(
+        default=1,
+        title="Maximum number of articles to download",
+        description="Stop after this many articles. Useful for testing and when using randomized order option. Note that this is applied *before* deduplication.",
+    )
+
+    randomized: bool = Field(
+        default=False,
+        title="Randomize Article Selection",
+        description="Make sure to set max_articles to something small if you use this!",
+    )
 
 
 class FullTextDownloadFlowOutput(BaseFlowOutput):
     """Output artifacts for the full-text download flow."""
-
     query_summary: MediacloudQuerySummary
     b2_artifact: FileUploadArtifact
 
@@ -76,6 +84,8 @@ def full_text_download_flow(params: FullTextDownloadParams) -> FullTextDownloadF
         end_date=params.end_date,
         dedup_strategy=params.dedup_strategy,
         upload_dedup_summary=params.upload_dedup_summary,
+        randomized=params.randomized,
+        max_articles=params.max_articles
     )
 
     logger.info(f"Retrieved {len(articles)} articles")

--- a/sous_chef/flows/llm_demo_flow.py
+++ b/sous_chef/flows/llm_demo_flow.py
@@ -25,7 +25,7 @@ class LLMDemoFlowParams(MediacloudQuery, GroqModelParams, CsvExportParams, Email
 
     max_articles: int = Field(
         default=1,
-        description="Maximum number of articles to summarize (for demos).",
+        description="Maximum number of articles to summarize (for demos). Note that this is applied *before* deduplication.",
     )
 
 
@@ -72,13 +72,10 @@ def llm_demo_flow(params: LLMDemoFlowParams) -> LLMDemoFlowOutput:
         end_date=params.end_date,
         dedup_strategy=params.dedup_strategy,
         upload_dedup_summary=params.upload_dedup_summary,
+        max_articles=params.max_articles,
     )
 
-    # Step 2: Limit articles for demo
-    if params.max_articles and params.max_articles > 0:
-        articles = articles.head(params.max_articles).copy()
-
-    # Step 3: Run LLM summarization task
+    # Step 2: Run LLM summarization task
     mark_step("llm_summarization_start", meta={"articles": len(articles)})
     articles_with_summaries, cost_summary = summarize_articles_llm(
         articles,
@@ -88,10 +85,10 @@ def llm_demo_flow(params: LLMDemoFlowParams) -> LLMDemoFlowOutput:
     )
     mark_step("llm_summarization_end", meta={"articles": len(articles_with_summaries)})
 
-    # Step 4: Prepare export data (remove full text column)
+    # Step 3: Prepare export data (remove full text column)
     export_df = articles_with_summaries.drop(columns=["text"], errors="ignore").copy()
 
-    # Step 5: Export results to Backblaze B2 as CSV
+    # Step 4: Export results to Backblaze B2 as CSV
     slug = create_url_safe_slug(params.query)
     object_name = (
         f"{params.b2_object_prefix}/DATE/{slug}-llm-summaries.csv"
@@ -104,7 +101,7 @@ def llm_demo_flow(params: LLMDemoFlowParams) -> LLMDemoFlowOutput:
         ensure_unique=params.b2_ensure_unique,
     )
 
-    # Step 6: Send email notification if recipients are specified
+    # Step 5: Send email notification if recipients are specified
     if params.email_to:
         email_result = send_run_summary_email(
             email_to=params.email_to,

--- a/sous_chef/flows/llm_quotes_flow.py
+++ b/sous_chef/flows/llm_quotes_flow.py
@@ -25,7 +25,7 @@ class LLMQuotesFlowParams(MediacloudQuery, GroqModelParams, CsvExportParams, Ema
 
     max_articles: int = Field(
         default=1,
-        description="Maximum number of articles to analyze (for demos).",
+        description="Maximum number of articles to analyze (for demos). Note that this is applied *before* deduplication.",
     )
 
 
@@ -58,13 +58,10 @@ def llm_quotes_flow(params: LLMQuotesFlowParams) -> LLMQuotesFlowOutput:
         end_date=params.end_date,
         dedup_strategy=params.dedup_strategy,
         upload_dedup_summary=params.upload_dedup_summary,
+        max_articles=params.max_articles,
     )
 
-    # Step 2: Limit articles for demo
-    if params.max_articles and params.max_articles > 0:
-        articles = articles.head(params.max_articles).copy()
-
-    # Step 3: Run task
+    # Step 2: Run task
     mark_step("llm_quotes_start", meta={"articles": len(articles)})
     quotes_df, cost_summary = article_quotes_llm(
         articles,
@@ -73,10 +70,7 @@ def llm_quotes_flow(params: LLMQuotesFlowParams) -> LLMQuotesFlowOutput:
     )
     mark_step("llm_quotes_end", meta={"quotes": len(quotes_df)})
 
-    # Step 4: Prepare export data (remove full text column)
-    # export_df = articles_with_summaries.drop(columns=["text"], errors="ignore").copy()
-
-    # Step 5: Export results to Backblaze B2 as CSV
+    # Step 3: Export results to Backblaze B2 as CSV
     slug = create_url_safe_slug(params.query)
     object_name = (
         f"{params.b2_object_prefix}/DATE/{slug}-llm-quotes.csv"
@@ -89,7 +83,7 @@ def llm_quotes_flow(params: LLMQuotesFlowParams) -> LLMQuotesFlowOutput:
         ensure_unique=params.b2_ensure_unique,
     )
 
-    # Step 6: Send email notification if recipients are specified
+    # Step 4: Send email notification if recipients are specified
     if params.email_to:
         email_result = send_run_summary_email(
             email_to=params.email_to,

--- a/sous_chef/tasks/discovery_tasks.py
+++ b/sous_chef/tasks/discovery_tasks.py
@@ -23,6 +23,8 @@ def query_online_news(
     source_ids: List[int] = [],
     dedup_strategy: DedupStrategy = DedupStrategy.none,
     upload_dedup_summary: bool = False,
+    randomized: bool = False,
+    max_articles: int = 0  # 0 means no limit in the UI
 ) -> ArtifactResult[pd.DataFrame]:
     """
     Query MediaCloud for news articles matching a search query.
@@ -43,18 +45,21 @@ def query_online_news(
     logger = get_logger()
     api_key = get_mediacloud_api_key()
     mc_search = mediacloud.api.SearchApi(api_key)
-    stories = []
+    story_pages = []  # this is a list of dataframes for some reason
     pagination_token = None
     more_stories = True
-    while more_stories:
+    total_articles = 0
+    while more_stories and (total_articles < max_articles if max_articles > 0 else True):
         try:
             page, pagination_token = mc_search.story_list(
-                query, 
-                start_date=start_date, 
-                end_date=end_date, 
-                collection_ids=collection_ids, 
+                query,
+                start_date=start_date,
+                end_date=end_date,
+                collection_ids=collection_ids,
                 source_ids=source_ids,
                 expanded=True,
+                randomized=randomized,
+                page_size=1000,
                 pagination_token=pagination_token
             )
             #time.sleep(5)
@@ -69,12 +74,17 @@ def query_online_news(
             # Re-raise API errors as-is
             raise e
         df = pd.DataFrame.from_records(page)
-        stories.append(df)
+        story_pages.append(df)
+        total_articles += len(df)
         more_stories = pagination_token is not None
 
     # Concatenate all pages into a single DataFrame and reset index to avoid
     # duplicate indices across pages, which can break downstream dedup logic.
-    stories_df = pd.concat(stories, ignore_index=True)
+    stories_df = pd.concat(story_pages, ignore_index=True)
+
+    # Truncate to max_articles after concat so we slice rows, not pages
+    if max_articles > 0:
+        stories_df = stories_df.head(max_articles)
 
     dedup_summary = None
     duplicates_file_artifact = None


### PR DESCRIPTION
This adds an option for randomized order on the existing full-text flow. To make this safer I also added a max_articles input that defaults to 1 (like the LLM flow) so that we don't forget and make huge paged randomized queries. 

To make this easier I also moved the max_articles check into the support function, so this doesn't query all the stories (stops  when it reaches max_articles).

I test this locally via CLI on a data pull via the JSON params file support and it works: `python run_flow.py full_text_download --params my-params.json`