### PR TITLE
Fix quotes prompt

### DIFF
--- a/sous_chef/prompts/quotes/v2-sauti-health.txt
+++ b/sous_chef/prompts/quotes/v2-sauti-health.txt
@@ -44,3 +44,6 @@ Return only a single valid JSON object. No explanation, no markdown, no code fen
     }
   ]
 }
+
+Here is the article to analyze:
+{text}

--- a/sous_chef/tasks/test/test_llm_quotes_tasks.py
+++ b/sous_chef/tasks/test/test_llm_quotes_tasks.py
@@ -22,13 +22,15 @@ class TestExtractQuotes(unittest.TestCase):
         # load sample stories from quote-samples.csv into a data frame
         with open(FIXTURE_1, "r") as f:
             samples = json.load(f)
-        # run the `text` from each story through the LLM function from the task
-        for story_idx, test_story in enumerate(samples):
-            # can't do .format call here because there are JSON format note in the prompt
-            story_prompt = load_prompt("quotes", "v2-sauti-health.txt").replace(
-                "{text}", test_story["text"]
-            )
-            output, usage = self._client.execute(story_prompt, ArticleQuotesOutput)
-            assert len(output.quotes) > 0
-            for q in output.quotes:
-                assert len(q.quote) > 0  # there is text that got extracted
+        base_prompt = load_prompt("quotes", "v2-sauti-health.txt")
+        # first story has many quotes
+        story_prompt0 = base_prompt.replace("{text}", samples[0]["text"])
+        output0, usage0 = self._client.execute(story_prompt0, ArticleQuotesOutput)
+        assert len(output0.quotes) > 0
+        for q in output0.quotes:
+            assert len(q.quote) > 0  # there is text that got extracted
+        # second one has none
+        story_prompt1 = base_prompt.replace("{text}", samples[1]["text"])
+        output1, usage1 = self._client.execute(story_prompt1, ArticleQuotesOutput)
+        assert len(output1.quotes) == 0
+

--- a/sous_chef/tasks/test/test_llm_quotes_tasks.py
+++ b/sous_chef/tasks/test/test_llm_quotes_tasks.py
@@ -29,5 +29,6 @@ class TestExtractQuotes(unittest.TestCase):
                 "{text}", test_story["text"]
             )
             output, usage = self._client.execute(story_prompt, ArticleQuotesOutput)
+            assert len(output.quotes) > 0
             for q in output.quotes:
                 assert len(q.quote) > 0  # there is text that got extracted


### PR DESCRIPTION
The results were returning empty, but successfully finishing, every time. Turns out I had a silly unit test that didn't catch that I had left the actual article text placeholder out of the revised prompt! Now I've fixed the unit test and run a pass that produced results locally, so I'm fairly confident in this. A tiny change to the input prompt.